### PR TITLE
fix import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
-import pathlib
 from setuptools import setup, find_packages
 
-# The directory containing this file
-HERE = pathlib.Path(__file__).parent
-
 # The text of the README file
-README = (HERE / "README.md").read_text()
+README = open("README.md").read()
 
 # This call to setup() does all the work
 setup(


### PR DESCRIPTION
Read in the contents of our `README.md` file in a way that (a) does not rely on the pathlib library and (b) doesn't rely on Python3 technology.