### PR TITLE
Address #18

### DIFF
--- a/codepost/models/abstract/api_crud.py
+++ b/codepost/models/abstract/api_crud.py
@@ -60,7 +60,7 @@ class CreatableAPIResource(_api_resource.AbstractAPIResource):
         the internal state of the instance, in addition to returning the new
         object.
         """
-        
+
         data = self._get_data_and_extend(**kwargs)
         obj = self.create(**data)
 
@@ -134,7 +134,7 @@ class UpdatableAPIResource(_api_resource.AbstractAPIResource):
 
         if not self._validate_id(id=_id):
             raise _errors.InvalidIDError()
-        
+
         # FIXME: do kwargs validation
         data = self._get_data_and_extend(static=True, **kwargs)
 
@@ -159,7 +159,7 @@ class UpdatableAPIResource(_api_resource.AbstractAPIResource):
 
         # FIXME: do kwargs validation
         # NOTE: "id" is contained in the self._data which is extended
-        data = self._get_data_and_extend(**kwargs)
+        data = self._get_data_and_extend(exclude_read_only=True, **kwargs)
         obj = self.update(**data)
 
         # Sanity check

--- a/codepost/models/abstract/api_crud.py
+++ b/codepost/models/abstract/api_crud.py
@@ -136,9 +136,9 @@ class UpdatableAPIResource(_api_resource.AbstractAPIResource):
             raise _errors.InvalidIDError()
 
         # FIXME: do kwargs validation
-        # Note: exclude_read_only is a form of kwargs validation (removing any read-only fields
-        # which are included). In the future, we could choose to warn they client when they
-        # attempt to update a read-only field (rather than siliently prrotecting them).
+        # Note: exclude_read_only is redundant kwargs validation (removing any read-only fields
+        # which are included). It is redundant because the type signature of cls.update is already
+        # factoried to exclude read_only fields
         data = self._get_data_and_extend(static=True, exclude_read_only=True, **kwargs)
 
         ret = self._requestor._request(

--- a/codepost/models/abstract/api_crud.py
+++ b/codepost/models/abstract/api_crud.py
@@ -136,7 +136,10 @@ class UpdatableAPIResource(_api_resource.AbstractAPIResource):
             raise _errors.InvalidIDError()
 
         # FIXME: do kwargs validation
-        data = self._get_data_and_extend(static=True, **kwargs)
+        # Note: exclude_read_only is a form of kwargs validation (removing any read-only fields
+        # which are included). In the future, we could choose to warn they client when they
+        # attempt to update a read-only field (rather than siliently prrotecting them).
+        data = self._get_data_and_extend(static=True, exclude_read_only=True, **kwargs)
 
         ret = self._requestor._request(
             endpoint=self.instance_endpoint_by_id(id=_id),

--- a/codepost/models/abstract/api_resource_metaclass.py
+++ b/codepost/models/abstract/api_resource_metaclass.py
@@ -198,7 +198,7 @@ class APIResourceMetaclass(type):
             # Create forge parameters
 
             for (key, val) in fields.items():
-                if key  in obj._FIELDS_READ_ONLY:
+                if key in obj._FIELDS_READ_ONLY:
                     continue
 
                 if all_optional or not key in obj._FIELDS_REQUIRED:

--- a/codepost/models/files.py
+++ b/codepost/models/files.py
@@ -39,7 +39,7 @@ class Files(
         'submission': (int, "The ID of the file's parent Submission."),
         'comments': (_typing.List[_comments.Comments], 'The IDs of all comments applied to this file.')
     }
-    _FIELDS_READ_ONLY = [ "dateEdited", "grade", "files" ]
+    _FIELDS_READ_ONLY = [ "dateEdited", "grade", "comments" ]
     _FIELDS_REQUIRED = [ "name", "code", "extension", "submission" ]
 
 # =============================================================================


### PR DESCRIPTION
## Problem
This bug is being caused by incompatible treatments of read-only fields in (a) the factoried signature of `cls.update` and (b) the helper method `_get_data_and_extend` used to implement `cls.save`.

`_get_data_and_extend` is used to pre-process an object prior to update [here](https://github.com/codepost-io/codepost-python/blob/3850e29e70747d60da7e482ec73f1a0894cbe0d1/codepost/models/abstract/api_crud.py#L139). When called from `cls.saveInstance`, this method will include in its return value all local instance fields, including read-only fields.

However, the type signature for `cls.update` [explicitly excludes read-only fields](https://github.com/codepost-io/codepost-python/blob/3850e29e70747d60da7e482ec73f1a0894cbe0d1/codepost/models/abstract/api_resource_metaclass.py#L201).

## Solution
Strip out read-only fields from the payload passed into `cls.update` within `cls.save`, as follows:
```
data = self._get_data_and_extend(exclude_read_only=True, **kwargs)
```

We don't need to use the `exclude_read_only` flag in the body of `cls.update`, because its signature already prevents users from specifying read-only fields to update.

## Future improvements
It would be nice to warn a user if he/she attempts to specify read-only fields at create or update read-only fields on update with a more specific error message.

## Misc
This PR also corrects a bug in the `file` model specification. Previously, `files` was specified as a read-only field instead of `comments` (likely a remnant of the submission model specification).