### PR TITLE
Add file.path to File schema

### DIFF
--- a/codepost/models/files.py
+++ b/codepost/models/files.py
@@ -37,9 +37,10 @@ class Files(
         'extension': (str,
         "The file extension. This field determines how the File's code will be syntax-highlighted."),
         'submission': (int, "The ID of the file's parent Submission."),
-        'comments': (_typing.List[_comments.Comments], 'The IDs of all comments applied to this file.')
+        'comments': (_typing.List[_comments.Comments], 'The IDs of all comments applied to this file.'),
+        'path': (str, 'An optional file path to indicate a directory structure within a submission.')
     }
-    _FIELDS_READ_ONLY = [ "dateEdited", "grade", "files" ]
+    _FIELDS_READ_ONLY = [ "dateEdited", "grade", "comments" ]
     _FIELDS_REQUIRED = [ "name", "code", "extension", "submission" ]
 
 # =============================================================================


### PR DESCRIPTION
This PR updates the `File` object schema to include the recently added `file.path` field, per https://docs.codepost.io/reference#the-file-object.