### PR TITLE
Windows Compatibility

### DIFF
--- a/codepost/util/custom_logging.py
+++ b/codepost/util/custom_logging.py
@@ -90,7 +90,7 @@ class _SimpleColorFormatter(_logging.Formatter):
         _t = _blessings.Terminal()
         f = lambda s: s.format(_t=_t) # Python 2 compatibility of f"..."
         self._title = {
-            "DEBUG":   f("{_t.normal}[{_t.bold}{_t.blue}DBUG{_t.normal}]"),
+            "DEBUG":   f("{_t.normal}[{_t.bold}{_t.blue}DEBUG{_t.normal}]"),
             "INFO":    f("{_t.normal}[{_t.bold}{_t.green}INFO{_t.normal}]"),
             "WARNING": f("{_t.normal}[{_t.bold}{_t.yellow}WARN{_t.normal}]"),
             "ERROR":   f("{_t.normal}[{_t.bold}{_t.red}ERR.{_t.normal}]"),

--- a/codepost/util/custom_logging.py
+++ b/codepost/util/custom_logging.py
@@ -91,7 +91,7 @@ class _SimpleColorFormatter(_logging.Formatter):
         _t = _blessings.Terminal()
         f = lambda s: s.format(_t=_t) # Python 2 compatibility of f"..."
         self._title = {
-            "DEBUG":   f("{_t.normal}[{_t.bold}{_t.blue}DEBUG{_t.normal}]"),
+            "DEBUG":   f("{_t.normal}[{_t.bold}{_t.blue}DBUG{_t.normal}]"),
             "INFO":    f("{_t.normal}[{_t.bold}{_t.green}INFO{_t.normal}]"),
             "WARNING": f("{_t.normal}[{_t.bold}{_t.yellow}WARN{_t.normal}]"),
             "ERROR":   f("{_t.normal}[{_t.bold}{_t.red}ERR.{_t.normal}]"),

--- a/codepost/util/custom_logging.py
+++ b/codepost/util/custom_logging.py
@@ -11,10 +11,10 @@ import logging as _logging
 import os as _os
 import time as _time
 import sys as _sys
+import platform as _platform
 
 # External imports
 import better_exceptions as _better_exceptions
-import blessings as _blessings
 import eliot
 import eliot.stdlib
 
@@ -87,6 +87,7 @@ class _SimpleColorFormatter(_logging.Formatter):
         Configure the formatter by initializing the colored terminal captions,
         for the log events which are output to standard output.
         """
+        import blessings as _blessings
         _t = _blessings.Terminal()
         f = lambda s: s.format(_t=_t) # Python 2 compatibility of f"..."
         self._title = {
@@ -157,8 +158,10 @@ def _setup_logging(name=None, level="INFO"):
         # Add the color handler to the terminal output
 
         handler = _logging.StreamHandler()#_QuietableStreamHandler()
-        formatter = _SimpleColorFormatter()
-        handler.setFormatter(formatter)
+
+        if _platform.system() != 'Windows':
+          formatter = _SimpleColorFormatter()
+          handler.setFormatter(formatter)
 
         # Set logging level of the terminal output (default to provided level)
 

--- a/codepost/version.py
+++ b/codepost/version.py
@@ -1,2 +1,2 @@
 # Version number
-__version__ = "0.2.15"
+__version__ = "0.2.16"


### PR DESCRIPTION
The `blessings` package which is used to format the Custom Logger is causing issues for some Windows users. 

As a short-term fix, we will only instantiate the custom log formatter for non-Windows clients. 

I successfully tested this fix on a Windows client (import codepost + standard usage).