### PR TITLE
fix trailing slashes from base url and assignments class formatter

### DIFF
--- a/codepost/models/abstract/api_resource.py
+++ b/codepost/models/abstract/api_resource.py
@@ -289,8 +289,7 @@ class APIResource(AbstractAPIResource):
                 pass
 
             # CASE 2: The class end point has not formatting parameter
-            # NOTE: Trailing slash important (API bug)
-            return urljoin(self.class_endpoint, "{}/".format(_id))
+            return urljoin(self.class_endpoint, "{}".format(_id))
 
     @property
     def instance_endpoint(self):

--- a/codepost/util/config.py
+++ b/codepost/util/config.py
@@ -71,7 +71,7 @@ from .misc import _make_f
 _LOG_SCOPE = "{}".format(__name__)
 
 SETTINGS_URL = "https://codepost.io/settings"
-BASE_URL = "https://api.codepost.io/"
+BASE_URL = "https://api.codepost.io"
 DEFAULT_API_KEY_ENV = "CP_API_KEY"
 DEFAULT_CONFIG_PATHS = [
     "codepost-config.yaml",

--- a/codepost/version.py
+++ b/codepost/version.py
@@ -1,2 +1,2 @@
 # Version number
-__version__ = "0.2.29"
+__version__ = "0.3.1"


### PR DESCRIPTION
the codePost api now handles trailing and duplicate slashes correctly, allowing us to remove the workarounds in the python SDK helpers