### PR TITLE
Update api_resource.py

### DIFF
--- a/codepost/models/abstract/api_resource.py
+++ b/codepost/models/abstract/api_resource.py
@@ -288,6 +288,15 @@ class APIResource(AbstractAPIResource):
             except IndexError: # means formatting didn't work
                 pass
 
+            # This is NOT the proper fix; I'm only making this change to get
+            # scripts working after the breaking change made to the API and to
+            # this code.  I have no idea if this is the only "weird" case or not
+            # but the API requires a trailing / when *updating* submissions.
+            # At least this change doesn't seem to affect the other REST actions
+            # (GET at least; didn't bother testing others)
+            if self.class_endpoint == "/submissions/":
+                return urljoin(self.class_endpoint, "{}/".format(_id))
+
             # CASE 2: The class end point has not formatting parameter
             return urljoin(self.class_endpoint, "{}".format(_id))
 


### PR DESCRIPTION
A temporary hot fix that needs a better solution.  The recent API and python codepost changes broke the API when attempting to update a submission.  The API seems to require a trailing slash for this specific operation.