### PR TITLE
resolve trailing slash on list_submissions

### DIFF
--- a/codepost/models/abstract/api_resource.py
+++ b/codepost/models/abstract/api_resource.py
@@ -289,7 +289,7 @@ class APIResource(AbstractAPIResource):
                 pass
 
             # CASE 2: The class end point has not formatting parameter
-            return urljoin(self.class_endpoint, "{}".format(_id))
+            return urljoin(self.class_endpoint, "{}/".format(_id))
 
     @property
     def instance_endpoint(self):

--- a/codepost/models/assignments.py
+++ b/codepost/models/assignments.py
@@ -116,7 +116,7 @@ class Assignments(
 
         id = self._get_id(id=id)
 
-        endpoint = "{}/submissions".format(self.instance_endpoint_by_id(id=id))
+        endpoint = "{}submissions".format(self.instance_endpoint_by_id(id=id))
         endpoint_params = {}
 
         if student != None:

--- a/codepost/version.py
+++ b/codepost/version.py
@@ -1,2 +1,2 @@
 # Version number
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
The recent change to the trailing slashes broke the `list_submissions` helper. This PR uses the better approach to addressing the double slash: https://github.com/codepost-io/codepost-python/pull/42

h/t @cbourke for [catching](https://github.com/codepost-io/codepost-python/pull/43/files)! 